### PR TITLE
Fix typos found by crate-ci typo checker

### DIFF
--- a/dist/TUTORIAL
+++ b/dist/TUTORIAL
@@ -17,7 +17,7 @@ input a Distfile which describes how and where files are to be installed.
 Rdist has been enhanced with some wrapper scripts to allow the lists of
 target nodes to come from genders.  The wrapper scripts scan the Distfile for
 references to specially formatted variables in which an attribute name has
-been embeded.  The special formats are:
+been embedded.  The special formats are:
 
      ${attr_xyz}
      ${cluster!attr_xyz}
@@ -372,7 +372,7 @@ To bring up a new cluster, the following tasks must be completed:
      modify dist2 to force rdist to use the kerberized rsh).  Rdist should
      already be installed on all the nodes.
   4.  Run the bootstrap script and dist2 -l on the repository node.
-  5.  Run dist2 on the respository node to update the other nodes.
+  5.  Run dist2 on the repository node to update the other nodes.
 
 Change Control
 

--- a/dist/dist2
+++ b/dist/dist2
@@ -245,13 +245,13 @@ if (defined($main::opt_f)) {
 		get_all_packages(\@packages);
 	}
 
-	# read Distfiles for specified packages and retrive attributes and labels
+	# read Distfiles for specified packages and retrieve attributes and labels
 	if (!findattrs_pkg(\@packages, \@found_labels, \@attrpairs)) {
-		# a package doesn't have correspoding Distfile (function emits error)
+		# a package doesn't have corresponding Distfile (function emits error)
 		exit(1);
 	}
 
-	# did we ask for nonexistant labels?
+	# did we ask for nonexistent labels?
 	if (!verify_labels(\@want_labels, \@found_labels)) {
 		# label not found in Distfile scan (function emits error)
 		exit(1);

--- a/dist/inst.c
+++ b/dist/inst.c
@@ -206,7 +206,7 @@ int main(int argc, char *argv[])
                 why = WHY_DESTNEWER;
             }
 
-            /* src newer than dest: probably install; not neccessarily */
+            /* src newer than dest: probably install; not necessarily */
         } else if (sb_dst.st_mtime < sb_src.st_mtime) {
 
             /* compare binary files */

--- a/man/dist/dist2.1
+++ b/man/dist/dist2.1
@@ -82,7 +82,7 @@ Node specification options are
 .I -g genders_query
 or
 .I -l.
-In the absense of these options,
+In the absence of these options,
 all nodes targeted by the preprocessed Distfile (potentially all nodes 
 appearing in the genders file) are updated.  
 .LP

--- a/man/dist/dist_all.1
+++ b/man/dist/dist_all.1
@@ -39,7 +39,7 @@ dist_all \- master rdist script
 The purpose of 
 .B dist_all
 is to broadcast files from the /var/dist rdist repository to nodes of a
-system.  In the absense of the 
+system.  In the absence of the 
 .I -w
 option, it executes
 .B "dist2 -v -l"


### PR DESCRIPTION
note: it's only after I fixed these that I noticed the last commit in this repo was 2015 and all these typo fixes are for obsolete and no longer used in production code.. Oh well. here it is anyways.