### PR TITLE
remove documentation trailing whitespace

### DIFF
--- a/man/dist/dist2.1
+++ b/man/dist/dist2.1
@@ -42,13 +42,13 @@ dist2 \- rdist wrapper
 .br
 .SH DESCRIPTION
 .B Dist2
-is a wrapper for USC 
+is a wrapper for USC
 .B rdist
 which adds a powerful macro capability based on the
 .I "genders file,"
 and abstracts a collection of Distfiles into an
 .I "rdist repository"
-made up of 
+made up of
 .I "packages"
 and
 .I "filesets."
@@ -62,13 +62,13 @@ VAR_DIST_IS_MOUNTED exists.
 specified on the command line.  If packages are specified, select
 Distfile.{package list}, otherwise Distfile.{all packages}.
 .IP
-3) Scan the Distfiles for macro references of the form ${attr_attrname} 
+3) Scan the Distfiles for macro references of the form ${attr_attrname}
 or ${attr_attrname=value} and
 prepend macro definitions based on the content of the genders file.
-In the example above, all nodes carrying the genders attribute 
+In the example above, all nodes carrying the genders attribute
 .I attrname
 or attribute and value
-.I attrname=value 
+.I attrname=value
 would be listed in the definition.
 .IP
 4) Send the resulting concatenation of Distfiles and macro definitions to
@@ -83,8 +83,8 @@ Node specification options are
 or
 .I -l.
 In the absence of these options,
-all nodes targeted by the preprocessed Distfile (potentially all nodes 
-appearing in the genders file) are updated.  
+all nodes targeted by the preprocessed Distfile (potentially all nodes
+appearing in the genders file) are updated.
 .LP
 Please see
 .B nodeattr(1)
@@ -103,64 +103,64 @@ command.
 similarly selects the set of nodes that have the specified genders attribute.
 .LP
 .I -l
-selects the local hostname (through genders).  
+selects the local hostname (through genders).
 .LP
 When the
 .I -l
 option is not used, the -x and -v options can be used to exclude a set of
-nodes.  
+nodes.
 The
 .I -x
 option can be used similarly to the
-.I -w 
+.I -w
 option to explicitly list a set of nodes to exclude.  The nodes should
 be specified as it appears in the genders file.  The
 .I -v
 option exclude nodes that
 .B whatsup(1)
-determines are down.  When both of the options are used, 
+determines are down.  When both of the options are used,
 .B dist2
-will first eliminate those nodes specified with the 
+will first eliminate those nodes specified with the
 .I -x
-option.  If 
+option.  If
 .B whatsup(1)
-is not installed, the 
-.I -v 
+is not installed, the
+.I -v
 option will fail.
 .LP
-When the -l option is specified, 
+When the -l option is specified,
 .B rdist
 will typically start the
 .B rdist
 server through a network connection, even though the server will run
 on the local machine.  In order to avoid this network connection, the
 .I -L
-option can be specified.  When the 
+option can be specified.  When the
 .I -L
 option is specified, each occurrence of the local hostname in the
 Distfiles is replaced with the string "localhost".  This forces
 .B rdist
-to run the 
+to run the
 .B rdist
-server locally in a shell. The 
+server locally in a shell. The
 .I -H
 option can be used to specify an alternate hostname to replace with
 the "localhost" string.
-The 
+The
 .I -L
-option can only be used when the 
-.I -l 
+option can only be used when the
+.I -l
 option is specified.  Similarly, the
 .I -H
-option can only be used when the 
-.I -l 
-and 
-.I -L 
+option can only be used when the
+.I -l
+and
+.I -L
 options are specified.
 .LP
 .I -i
 selects canonical hostnames (the left hand side of a genders file entry).
-The default on the SP is to convert these "initial_hostname" values to 
+The default on the SP is to convert these "initial_hostname" values to
 "reliable_hostname" via the SDR.  Elsewhere, the conversion is based on
 taking the value of an "altname" genders attribute, if any.  This option
 defeats this conversion.
@@ -169,22 +169,22 @@ The
 .I -o
 option can be used to pass options to
 .B rdist.
-The 
-.I -o 
+The
+.I -o
 option's arguments are identical to those specified in the
 .B rdist(1)
 manpage.
-The 
+The
 .I -V
 option can be used as shorthand to pass the "verify" option to rdist.
 .LP
-The 
-.I -P 
+The
+.I -P
 option can be used to pass an alternate transport program to rdist, so
 that rdist may use it rather than the default of
-.B rsh(1).  
-The 
-.I -P 
+.B rsh(1).
+The
+.I -P
 option's argument should be specified just as it is specified in the
 .B rdist
 manpage.  An alternate transport program can also be specified via the
@@ -195,11 +195,11 @@ is used for debugging Distfile problems.  When
 .B rdist
 reports a syntax error, it refers to line numbers in the preprocessed
 Distfile.  This option provides a means for the Distfile author to see
-the preprocessed version.  If 
-.I -n 
+the preprocessed version.  If
+.I -n
 is also specified, line numbers will be prepended to each line.
 .LP
-The 
+The
 .I -c
 option can be used to specify an alternate cluster to the one
 .B dist2
@@ -218,28 +218,28 @@ ${clustername!attr_attrname} or ${clustername!attr_attrname=value}.
 These definitions expand to empty lists on clusters other than the one
 specified.
 .LP
-Put another way, ${attr_attrname} refers to all nodes in all clusters with the 
+Put another way, ${attr_attrname} refers to all nodes in all clusters with the
 .I attrname
 attribute, ${attr_attrname=value} refers to all nodes in all clusters with
-the 
+the
 .I attrname
 attribute equal to
 .I value.
-${clustername!attr_attrname} only refers to the nodes in 
+${clustername!attr_attrname} only refers to the nodes in
 .I clustername
-with the 
+with the
 .I attrname
 attribute, and ${clustername!attr_attrname=value} only refers to the nodes in
 .I clustername
-with the 
+with the
 .I attrname
 attribute equal to
 .I value.
 .LP
-You can also substitute genders values using 
-.I ${attrval_[value]}.  
+You can also substitute genders values using
+.I ${attrval_[value]}.
 For instance
-.I ${attrval_cluster} 
+.I ${attrval_cluster}
 would substitute the name of the cluster that dist2 was running on.
 This can be very useful.  Take for example the following case...
 
@@ -248,11 +248,11 @@ genders/genders.${attrval_cluster} -> ${${attrval_cluster}!attr_all}
 
 The above example could be used to install a cluster specific genders
 file on any number of clusters.  This also make adding new clusters to
-your rdist scheme trivial as all you need to do is create a 
+your rdist scheme trivial as all you need to do is create a
 genders.[clustername] file.
 
 Note that trying to reference a genders attribute that either doesn't
-have an associated value or does not exist will cause processing of 
+have an associated value or does not exist will cause processing of
 that file to abort.  The dist2 script will however continue processing
 with the next file.
 

--- a/man/dist/dist_all.1
+++ b/man/dist/dist_all.1
@@ -36,27 +36,27 @@ dist_all \- master rdist script
 .B dist_all
 .I "-l"
 .SH DESCRIPTION
-The purpose of 
+The purpose of
 .B dist_all
 is to broadcast files from the /var/dist rdist repository to nodes of a
-system.  In the absence of the 
+system.  In the absence of the
 .I -w
 option, it executes
 .B "dist2 -v -l"
-on all nodes.  
+on all nodes.
 .B "dist2"
 in turn runs rdist against files located in the NFS-mounted rdist repository,
 /var/dist.
 .LP
-Any arguments not interpreted by 
+Any arguments not interpreted by
 .B "dist_all"
-are passed on to 
+are passed on to
 .B "dist2".
-Typically these include the names of packages/filesets or the 
+Typically these include the names of packages/filesets or the
 .I -w
 option and a list of nodes.
 .LP
-Packages are groups of files managed by a single Distfile in /var/dist, and 
+Packages are groups of files managed by a single Distfile in /var/dist, and
 filesets are labels within Distfiles.  If no packages are specified, everything
 in /var/dist is sent out.  To get a list of valid packages, run
 .B "dist_all -l"
@@ -65,9 +65,9 @@ The
 .I -w
 option takes a comma-separated list of nodes.  If no nodes are specified, all
 nodes in the system are assumed.  Nodes should always be specified
-using initial_hostnames.  Use 
+using initial_hostnames.  Use
 .I -i
-to request that 
+to request that
 .B dist2
 internally use canonical hostnames.
 .LP

--- a/man/dist/dist_cmp.1
+++ b/man/dist/dist_cmp.1
@@ -34,32 +34,32 @@ dist_cmp \- compress rdist output
 .br
 .SH DESCRIPTION
 .B Dist_cmp
-is to 
-.B dist_all 
-what 
-.B dshbak 
-is to 
+is to
+.B dist_all
+what
+.B dshbak
+is to
 .B "pdsh."
 .B Dist_cmp
-compresses 
-.B rdist 
+compresses
+.B rdist
 output and makes it more readable by:
 .LP
-1. Displaying all the output for a particular node on successive lines instead 
+1. Displaying all the output for a particular node on successive lines instead
 of in the order received.
 .LP
-2. Displaying only one copy of a line of output that is identical for multiple 
+2. Displaying only one copy of a line of output that is identical for multiple
 nodes, along with a list of nodes that produced this output.
 .LP
 3. Compressing long lists of node names that have numeric suffixes into ranges,
-e.g. 
+e.g.
 .I "blue001,blue002,blue003"
 becomes
 .I "blue001-003".
 .LP
 4. Separating multiple rdist sessions for a given node or list of nodes.
 This is necessary as
-.B dist_all 
+.B dist_all
 updates mirror hosts twice:  once for the mirror, and once from the mirror
 to the final destination.
 

--- a/man/dist/dist_local.1
+++ b/man/dist/dist_local.1
@@ -33,7 +33,7 @@ dist_local \- local rdist script
 .B dist_local
 .I "[package[.fileset]] ..."
 .SH DESCRIPTION
-The purpose of 
+The purpose of
 .B dist_local
 is to update files on the local node from the /var/dist rdist repository.
 It simply executes
@@ -46,7 +46,7 @@ in turn runs rdist against files located in the NFS-mounted rdist repository,
 All arguments are passed on to
 .B "dist2."
 Typically these include the names of packages/filesets to be updated.
-Packages are groups of files managed by a single Distfile in /var/dist, and 
+Packages are groups of files managed by a single Distfile in /var/dist, and
 filesets are labels within Distfiles.  If no packages are specified, everything
 in /var/dist updated.
 .LP
@@ -54,26 +54,26 @@ When
 .B dist_local
 is executed,
 .B rdist
-will typically start the 
+will typically start the
 .B rdist
 server through a network connection, even though the server will run
 on the local machine.  In order to avoid this network connection, the
 .I -L
-option can be specified.  When the 
+option can be specified.  When the
 .I -L
 option is specified, each occurrence of the local hostname in the
 Distfiles is replaced with the string "localhost".  This forces
 .B rdist
-to run the 
+to run the
 .B rdist
-server locally in a shell. The 
+server locally in a shell. The
 .I -H
 option can be used to specify an alternate hostname to replace with
 the "localhost" string.
 The
 .I -H
-option can only be used when the 
-.I -L 
+option can only be used when the
+.I -L
 option is specified.
 .LP
 .SH "SEE ALSO"

--- a/man/dist/inst.1
+++ b/man/dist/inst.1
@@ -34,17 +34,17 @@ inst \- install files
 .I "-s file -d dstdir [-m mode] [-o owner] [-g group] [-c|-C] [-f] [-q]"
 .br
 .SH DESCRIPTION
-.B Inst 
-is similar to installbsd(1) but does not perform the install if it determines 
+.B Inst
+is similar to installbsd(1) but does not perform the install if it determines
 the destination file to be already up to date.
 .LP
-.B "-f" 
-can be used to force the install.  If this option is not specified, a 
+.B "-f"
+can be used to force the install.  If this option is not specified, a
 destination file with modification time equal to or greater than the source
 file will not be overwritten.
 .LP
 .B "-c"
-requests that the 
+requests that the
 .I "cmp"
 command be used to compare source and destination files, and to install only
 if they do not match.
@@ -65,7 +65,7 @@ If the
 .B "-o,"
 or
 .B "-g"
-options are not specified, the file is installed with the same mode, owner, 
+options are not specified, the file is installed with the same mode, owner,
 or group, respectively, as the source file.
 
 .SH "SEE ALSO"

--- a/man/genders_altnodelist_clear.3
+++ b/man/genders_altnodelist_clear.3
@@ -6,23 +6,23 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Gendersllnl, a cluster configuration database
 .\"  and rdist preprocessor for LLNL site specific needs.  This package
 .\"  was originally a part of the Genders package, but has now been
 .\"  split off into a separate package.  For details, see
 .\"  <http://www.llnl.gov/linux/genders/>.
-.\"  
-.\"  Gendersllnl is free software; you can redistribute it and/or modify it 
+.\"
+.\"  Gendersllnl is free software; you can redistribute it and/or modify it
 .\"  under the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Gendersllnl is distributed in the hope that it will be useful, but WITHOUT
-.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 .\"  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
 .\"  for more details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Gendersllnl.  If not, see <http://www.gnu.org/licenses/>.
 .\"##########################################################################

--- a/man/genders_altnodelist_create.3
+++ b/man/genders_altnodelist_create.3
@@ -6,23 +6,23 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Gendersllnl, a cluster configuration database
 .\"  and rdist preprocessor for LLNL site specific needs.  This package
 .\"  was originally a part of the Genders package, but has now been
 .\"  split off into a separate package.  For details, see
 .\"  <http://www.llnl.gov/linux/genders/>.
-.\"  
-.\"  Gendersllnl is free software; you can redistribute it and/or modify it 
+.\"
+.\"  Gendersllnl is free software; you can redistribute it and/or modify it
 .\"  under the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Gendersllnl is distributed in the hope that it will be useful, but WITHOUT
-.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 .\"  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
 .\"  for more details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Gendersllnl.  If not, see <http://www.gnu.org/licenses/>.
 .\"##########################################################################

--- a/man/genders_altnodelist_destroy.3
+++ b/man/genders_altnodelist_destroy.3
@@ -6,23 +6,23 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Gendersllnl, a cluster configuration database
 .\"  and rdist preprocessor for LLNL site specific needs.  This package
 .\"  was originally a part of the Genders package, but has now been
 .\"  split off into a separate package.  For details, see
 .\"  <http://www.llnl.gov/linux/genders/>.
-.\"  
-.\"  Gendersllnl is free software; you can redistribute it and/or modify it 
+.\"
+.\"  Gendersllnl is free software; you can redistribute it and/or modify it
 .\"  under the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Gendersllnl is distributed in the hope that it will be useful, but WITHOUT
-.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 .\"  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
 .\"  for more details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Gendersllnl.  If not, see <http://www.gnu.org/licenses/>.
 .\"##########################################################################

--- a/man/genders_get_cluster.3
+++ b/man/genders_get_cluster.3
@@ -6,23 +6,23 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Gendersllnl, a cluster configuration database
 .\"  and rdist preprocessor for LLNL site specific needs.  This package
 .\"  was originally a part of the Genders package, but has now been
 .\"  split off into a separate package.  For details, see
 .\"  <http://www.llnl.gov/linux/genders/>.
-.\"  
-.\"  Gendersllnl is free software; you can redistribute it and/or modify it 
+.\"
+.\"  Gendersllnl is free software; you can redistribute it and/or modify it
 .\"  under the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Gendersllnl is distributed in the hope that it will be useful, but WITHOUT
-.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 .\"  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
 .\"  for more details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Gendersllnl.  If not, see <http://www.gnu.org/licenses/>.
 .\"##########################################################################
@@ -43,15 +43,15 @@ retrieved.  The cluster name is stored in the buffer pointed to be
 To avoid passing in a buffer that is not large enough to store the
 cluster name,
 .BR genders_getmaxvallen (3)
-should be used to determine the minimum buffer size that should be used. 
+should be used to determine the minimum buffer size that should be used.
 .br
 .SH RETURN VALUES
 On success, 0 is returned.  On error, -1 is returned, and an error code
 is returned in \fIhandle\fR.  The error code can be retrieved
 via
 .BR genders_errnum (3)
-, and a description of the error code can be retrieved via 
-.BR genders_strerror (3).  
+, and a description of the error code can be retrieved via
+.BR genders_strerror (3).
 Error codes are defined in genders.h.
 .br
 .SH ERRORS
@@ -70,13 +70,13 @@ The buffer pointed to by \fIbuf\fR is not large enough to store the
 cluster name.
 .TP
 .B GENDERS_ERR_PARAMETERS
-An incorrect parameter has been passed in.  
+An incorrect parameter has been passed in.
 .TP
 .B GENDERS_ERR_NOTFOUND
 The node pointed to bey \fInode\fR cannot be found in the genders
 file.
 .TP
-.B GENDERS_ERR_MAGIC 
+.B GENDERS_ERR_MAGIC
 \fIhandle\fR has an incorrect magic number.  \fIhandle\fR does not
 point to a genders handle or \fIhandle\fR has been destroyed by
 .BR genders_handle_destroy (3).

--- a/man/genders_getaltnodes.3
+++ b/man/genders_getaltnodes.3
@@ -6,23 +6,23 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Gendersllnl, a cluster configuration database
 .\"  and rdist preprocessor for LLNL site specific needs.  This package
 .\"  was originally a part of the Genders package, but has now been
 .\"  split off into a separate package.  For details, see
 .\"  <http://www.llnl.gov/linux/genders/>.
-.\"  
-.\"  Gendersllnl is free software; you can redistribute it and/or modify it 
+.\"
+.\"  Gendersllnl is free software; you can redistribute it and/or modify it
 .\"  under the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Gendersllnl is distributed in the hope that it will be useful, but WITHOUT
-.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 .\"  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
 .\"  for more details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Gendersllnl.  If not, see <http://www.gnu.org/licenses/>.
 .\"##########################################################################
@@ -58,7 +58,7 @@ name of the original genders node.
 
 To avoid passing in a list that is not large enough to store all the
 nodes,
-.BR genders_altnodelist_create (3) 
+.BR genders_altnodelist_create (3)
 should be used to create a list that is guaranteed to be large enough
 to store all alternate names of the nodes.
 .br
@@ -67,8 +67,8 @@ On success, the number of alternate node names stored in
 \fIaltnodes\fR is returned.  On error, -1 is returned, and an error
 code is returned in \fIhandle\fR.  The error code can be retrieved via
 .BR genders_errnum (3)
-, and a description of the error code can be retrieved via 
-.BR genders_strerror (3).  
+, and a description of the error code can be retrieved via
+.BR genders_strerror (3).
 Error codes are defined in genders.h.
 .br
 .SH ERRORS
@@ -87,16 +87,16 @@ The list pointed to by \fIaltnodes\fR is not large enough to store all
 the alternate node names.
 .TP
 .B GENDERS_ERR_PARAMETERS
-An incorrect parameter has been passed in.  
+An incorrect parameter has been passed in.
 .TP
 .B GENDERS_ERR_NULLPTR
 A null pointer has been found in the list passed in.
 .TP
 .B GENDERS_ERR_OUTMEM
-.BR malloc (3) 
+.BR malloc (3)
 has failed internally, system is out of memory.
 .TP
-.B GENDERS_ERR_MAGIC 
+.B GENDERS_ERR_MAGIC
 \fIhandle\fR has an incorrect magic number.  \fIhandle\fR does not
 point to a genders handle or \fIhandle\fR has been destroyed by
 .BR genders_handle_destroy (3).

--- a/man/genders_getaltnodes_preserve.3
+++ b/man/genders_getaltnodes_preserve.3
@@ -6,23 +6,23 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Gendersllnl, a cluster configuration database
 .\"  and rdist preprocessor for LLNL site specific needs.  This package
 .\"  was originally a part of the Genders package, but has now been
 .\"  split off into a separate package.  For details, see
 .\"  <http://www.llnl.gov/linux/genders/>.
-.\"  
-.\"  Gendersllnl is free software; you can redistribute it and/or modify it 
+.\"
+.\"  Gendersllnl is free software; you can redistribute it and/or modify it
 .\"  under the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Gendersllnl is distributed in the hope that it will be useful, but WITHOUT
-.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 .\"  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
 .\"  for more details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Gendersllnl.  If not, see <http://www.gnu.org/licenses/>.
 .\"##########################################################################

--- a/man/genders_isaltnode.3
+++ b/man/genders_isaltnode.3
@@ -6,23 +6,23 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Gendersllnl, a cluster configuration database
 .\"  and rdist preprocessor for LLNL site specific needs.  This package
 .\"  was originally a part of the Genders package, but has now been
 .\"  split off into a separate package.  For details, see
 .\"  <http://www.llnl.gov/linux/genders/>.
-.\"  
-.\"  Gendersllnl is free software; you can redistribute it and/or modify it 
+.\"
+.\"  Gendersllnl is free software; you can redistribute it and/or modify it
 .\"  under the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Gendersllnl is distributed in the hope that it will be useful, but WITHOUT
-.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 .\"  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
 .\"  for more details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Gendersllnl.  If not, see <http://www.gnu.org/licenses/>.
 .\"##########################################################################
@@ -57,8 +57,8 @@ returned.  If it is not listed, 0 is returned.
 On error, all both return -1 and an error code is returned in
 \fIhandle\fR.  The error code can be retrieved via
 .BR genders_errnum (3)
-, and a description of the error code can be retrieved via 
-.BR genders_strerror (3).  
+, and a description of the error code can be retrieved via
+.BR genders_strerror (3).
 Error codes are defined in genders.h.
 .br
 .SH ERRORS
@@ -73,9 +73,9 @@ with
 has not been called to load genders data.
 .TP
 .B GENDERS_ERR_PARAMETERS
-An incorrect parameter has been passed in.  
+An incorrect parameter has been passed in.
 .TP
-.B GENDERS_ERR_MAGIC 
+.B GENDERS_ERR_MAGIC
 \fIhandle\fR has an incorrect magic number.  \fIhandle\fR does not
 point to a genders handle or \fIhandle\fR has been destroyed by
 .BR genders_handle_destroy (3).

--- a/man/genders_isnode_or_altnode.3
+++ b/man/genders_isnode_or_altnode.3
@@ -6,23 +6,23 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Gendersllnl, a cluster configuration database
 .\"  and rdist preprocessor for LLNL site specific needs.  This package
 .\"  was originally a part of the Genders package, but has now been
 .\"  split off into a separate package.  For details, see
 .\"  <http://www.llnl.gov/linux/genders/>.
-.\"  
-.\"  Gendersllnl is free software; you can redistribute it and/or modify it 
+.\"
+.\"  Gendersllnl is free software; you can redistribute it and/or modify it
 .\"  under the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Gendersllnl is distributed in the hope that it will be useful, but WITHOUT
-.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 .\"  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
 .\"  for more details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Gendersllnl.  If not, see <http://www.gnu.org/licenses/>.
 .\"##########################################################################

--- a/man/genders_string_to_altnames.3
+++ b/man/genders_string_to_altnames.3
@@ -6,23 +6,23 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Gendersllnl, a cluster configuration database
 .\"  and rdist preprocessor for LLNL site specific needs.  This package
 .\"  was originally a part of the Genders package, but has now been
 .\"  split off into a separate package.  For details, see
 .\"  <http://www.llnl.gov/linux/genders/>.
-.\"  
-.\"  Gendersllnl is free software; you can redistribute it and/or modify it 
+.\"
+.\"  Gendersllnl is free software; you can redistribute it and/or modify it
 .\"  under the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Gendersllnl is distributed in the hope that it will be useful, but WITHOUT
-.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 .\"  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
 .\"  for more details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Gendersllnl.  If not, see <http://www.gnu.org/licenses/>.
 .\"##########################################################################

--- a/man/genders_string_to_altnames_preserve.3
+++ b/man/genders_string_to_altnames_preserve.3
@@ -6,23 +6,23 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Gendersllnl, a cluster configuration database
 .\"  and rdist preprocessor for LLNL site specific needs.  This package
 .\"  was originally a part of the Genders package, but has now been
 .\"  split off into a separate package.  For details, see
 .\"  <http://www.llnl.gov/linux/genders/>.
-.\"  
-.\"  Gendersllnl is free software; you can redistribute it and/or modify it 
+.\"
+.\"  Gendersllnl is free software; you can redistribute it and/or modify it
 .\"  under the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Gendersllnl is distributed in the hope that it will be useful, but WITHOUT
-.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 .\"  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
 .\"  for more details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Gendersllnl.  If not, see <http://www.gnu.org/licenses/>.
 .\"##########################################################################

--- a/man/genders_string_to_gendnames.3
+++ b/man/genders_string_to_gendnames.3
@@ -6,23 +6,23 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Gendersllnl, a cluster configuration database
 .\"  and rdist preprocessor for LLNL site specific needs.  This package
 .\"  was originally a part of the Genders package, but has now been
 .\"  split off into a separate package.  For details, see
 .\"  <http://www.llnl.gov/linux/genders/>.
-.\"  
-.\"  Gendersllnl is free software; you can redistribute it and/or modify it 
+.\"
+.\"  Gendersllnl is free software; you can redistribute it and/or modify it
 .\"  under the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Gendersllnl is distributed in the hope that it will be useful, but WITHOUT
-.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 .\"  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
 .\"  for more details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Gendersllnl.  If not, see <http://www.gnu.org/licenses/>.
 .\"##########################################################################

--- a/man/genders_string_to_gendnames_preserve.3
+++ b/man/genders_string_to_gendnames_preserve.3
@@ -6,23 +6,23 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Gendersllnl, a cluster configuration database
 .\"  and rdist preprocessor for LLNL site specific needs.  This package
 .\"  was originally a part of the Genders package, but has now been
 .\"  split off into a separate package.  For details, see
 .\"  <http://www.llnl.gov/linux/genders/>.
-.\"  
-.\"  Gendersllnl is free software; you can redistribute it and/or modify it 
+.\"
+.\"  Gendersllnl is free software; you can redistribute it and/or modify it
 .\"  under the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Gendersllnl is distributed in the hope that it will be useful, but WITHOUT
-.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 .\"  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
 .\"  for more details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Gendersllnl.  If not, see <http://www.gnu.org/licenses/>.
 .\"##########################################################################

--- a/man/genders_to_altname.3
+++ b/man/genders_to_altname.3
@@ -6,23 +6,23 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Gendersllnl, a cluster configuration database
 .\"  and rdist preprocessor for LLNL site specific needs.  This package
 .\"  was originally a part of the Genders package, but has now been
 .\"  split off into a separate package.  For details, see
 .\"  <http://www.llnl.gov/linux/genders/>.
-.\"  
-.\"  Gendersllnl is free software; you can redistribute it and/or modify it 
+.\"
+.\"  Gendersllnl is free software; you can redistribute it and/or modify it
 .\"  under the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Gendersllnl is distributed in the hope that it will be useful, but WITHOUT
-.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 .\"  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
 .\"  for more details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Gendersllnl.  If not, see <http://www.gnu.org/licenses/>.
 .\"##########################################################################

--- a/man/genders_to_altname_preserve.3
+++ b/man/genders_to_altname_preserve.3
@@ -6,23 +6,23 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Gendersllnl, a cluster configuration database
 .\"  and rdist preprocessor for LLNL site specific needs.  This package
 .\"  was originally a part of the Genders package, but has now been
 .\"  split off into a separate package.  For details, see
 .\"  <http://www.llnl.gov/linux/genders/>.
 .\"
-.\"  Gendersllnl is free software; you can redistribute it and/or modify it 
+.\"  Gendersllnl is free software; you can redistribute it and/or modify it
 .\"  under the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Gendersllnl is distributed in the hope that it will be useful, but WITHOUT
-.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 .\"  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
 .\"  for more details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Gendersllnl.  If not, see <http://www.gnu.org/licenses/>.
 .\"##########################################################################

--- a/man/genders_to_gendname.3
+++ b/man/genders_to_gendname.3
@@ -6,22 +6,22 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Gendersllnl, a cluster configuration database
 .\"  and rdist preprocessor for LLNL site specific needs.  This package
 .\"  was originally a part of the Genders package, but has now been
 .\"  split off into a separate package.  For details, see
 .\"  <http://www.llnl.gov/linux/genders/>.
-.\"  Gendersllnl is free software; you can redistribute it and/or modify it 
+.\"  Gendersllnl is free software; you can redistribute it and/or modify it
 .\"  under the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Gendersllnl is distributed in the hope that it will be useful, but WITHOUT
-.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 .\"  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
 .\"  for more details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Gendersllnl.  If not, see <http://www.gnu.org/licenses/>.
 .\"##########################################################################

--- a/man/genders_to_gendname_preserve.3
+++ b/man/genders_to_gendname_preserve.3
@@ -6,23 +6,23 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Gendersllnl, a cluster configuration database
 .\"  and rdist preprocessor for LLNL site specific needs.  This package
 .\"  was originally a part of the Genders package, but has now been
 .\"  split off into a separate package.  For details, see
 .\"  <http://www.llnl.gov/linux/genders/>.
 .\"
-.\"  Gendersllnl is free software; you can redistribute it and/or modify it 
+.\"  Gendersllnl is free software; you can redistribute it and/or modify it
 .\"  under the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Gendersllnl is distributed in the hope that it will be useful, but WITHOUT
-.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 .\"  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
 .\"  for more details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Gendersllnl.  If not, see <http://www.gnu.org/licenses/>.
 .\"##########################################################################

--- a/man/gendersllnl.3
+++ b/man/gendersllnl.3
@@ -6,23 +6,23 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Gendersllnl, a cluster configuration database
 .\"  and rdist preprocessor for LLNL site specific needs.  This package
 .\"  was originally a part of the Genders package, but has now been
 .\"  split off into a separate package.  For details, see
 .\"  <http://www.llnl.gov/linux/genders/>.
-.\"  
-.\"  Gendersllnl is free software; you can redistribute it and/or modify it 
+.\"
+.\"  Gendersllnl is free software; you can redistribute it and/or modify it
 .\"  under the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Gendersllnl is distributed in the hope that it will be useful, but WITHOUT
-.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 .\"  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
 .\"  for more details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Gendersllnl.  If not, see <http://www.gnu.org/licenses/>.
 .\"##########################################################################

--- a/man/libgendersllnl.3
+++ b/man/libgendersllnl.3
@@ -6,29 +6,29 @@
 .\"  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 .\"  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 .\"  UCRL-CODE-2003-004.
-.\"  
+.\"
 .\"  This file is part of Gendersllnl, a cluster configuration database
 .\"  and rdist preprocessor for LLNL site specific needs.  This package
 .\"  was originally a part of the Genders package, but has now been
 .\"  split off into a separate package.  For details, see
 .\"  <http://www.llnl.gov/linux/genders/>.
-.\"  
-.\"  Gendersllnl is free software; you can redistribute it and/or modify it 
+.\"
+.\"  Gendersllnl is free software; you can redistribute it and/or modify it
 .\"  under the terms of the GNU General Public License as published by the Free
 .\"  Software Foundation; either version 2 of the License, or (at your option)
 .\"  any later version.
-.\"  
+.\"
 .\"  Gendersllnl is distributed in the hope that it will be useful, but WITHOUT
-.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+.\"  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 .\"  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
 .\"  for more details.
-.\"  
+.\"
 .\"  You should have received a copy of the GNU General Public License along
 .\"  with Gendersllnl.  If not, see <http://www.gnu.org/licenses/>.
 .\"##########################################################################
 .TH LIBGENDERSLLNL 3 "August 2003" "LLNL" "LIBGENDERSLLNL"
 .SH NAME
-libgendersllnl \- a library of LLNL site specific genders functions 
+libgendersllnl \- a library of LLNL site specific genders functions
 .SH SYNOPSIS
 .B #include <gendersllnl.h>
 .sp
@@ -67,7 +67,7 @@ libgendersllnl \- a library of LLNL site specific genders functions
 .SH DESCRIPTION
 The gendersllnl library functions are an additional set of genders
 parsing functions that are specific to LLNL.  The API works similarly
-to the 
+to the
 .BR libgenders (3)
 API and requires that a genders handle be created, genders data be
 loaded, and the genders handle passed to individual functions.


### PR DESCRIPTION
Problem: There was some trailing whitespace in documentation.

Remove it.