### PR TITLE
remove perl extensions trailing whitespace

### DIFF
--- a/src/Gendersllnl/Gendersllnl.pm.in
+++ b/src/Gendersllnl/Gendersllnl.pm.in
@@ -6,18 +6,18 @@
 #  Produced at Lawrence Livermore National Laboratory (cf, DISCLAIMER).
 #  Written by Jim Garlick <garlick@llnl.gov> and Albert Chu <chu11@llnl.gov>.
 #  UCRL-CODE-2003-004.
-#  
+#
 #  This file is part of Gendersllnl, a cluster configuration database
 #  and rdist preprocessor for LLNL site specific needs.  This package
 #  was originally a part of the Genders package, but has now been
 #  split off into a separate package.  For details, see
 #  <http://www.llnl.gov/linux/genders/>.
-#  
+#
 #  Gendersllnl is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or (at
 #  your option) any later version.
-#   
+#
 #  Gendersllnl is distributed in the hope that it will be useful, but
 #  WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
@@ -44,9 +44,9 @@ sub new {
     my $self = {};
     my $handle;
     my $rv;
-    
+
     $self->{$debugkey} = 0;
-    
+
     $handle = Libgendersllnl->genders_handle_create();
     if (!defined($handle)) {
         _errormsg($self, "genders_handle_create()");
@@ -59,7 +59,7 @@ sub new {
     if ($rv < 0) {
         _errormsg($self, "genders_load_data()");
         return undef;
-    } 
+    }
 
     bless ($self, $class);
     return $self;
@@ -109,13 +109,13 @@ sub getaltnodes_preserve {
     my $altnodes;
 
     if (ref($self)) {
-        $altnodes = $self->{$handlekey}->genders_getaltnodes_preserve($attr, 
+        $altnodes = $self->{$handlekey}->genders_getaltnodes_preserve($attr,
                                                                       $val);
         if (!defined($altnodes)) {
             _errormsg($self, "genders_getaltnodes_preserve()");
             return ();
         }
-        
+
         return @$altnodes;
     }
     else {
@@ -134,7 +134,7 @@ sub isaltnode {
             _errormsg($self, "genders_isaltnode()");
             return 0;
         }
-        return $rv; 
+        return $rv;
     }
     else {
         return 0;
@@ -152,7 +152,7 @@ sub isnode_or_altnode {
             _errormsg($self, "genders_isnode_or_altnode()");
             return 0;
         }
-        return $rv; 
+        return $rv;
     }
     else {
         return 0;
@@ -170,7 +170,7 @@ sub to_gendname {
             _errormsg($self, "genders_to_gendname()");
             return "";
         }
-        return $gendname; 
+        return $gendname;
     }
     else {
         return "";
@@ -188,7 +188,7 @@ sub to_gendname_preserve {
             _errormsg($self, "genders_to_gendname_preserve()");
             return "";
         }
-        return $gendname; 
+        return $gendname;
     }
     else {
         return "";
@@ -206,7 +206,7 @@ sub to_altname {
             _errormsg($self, "genders_to_altname()");
             return "";
         }
-        return $altname; 
+        return $altname;
     }
     else {
         return "";
@@ -224,7 +224,7 @@ sub to_altname_preserve {
             _errormsg($self, "genders_to_altname_preserve()");
             return "";
         }
-        return $altname; 
+        return $altname;
     }
     else {
         return "";
@@ -290,7 +290,7 @@ sub to_altnames {
             }
             push(@altnames, $altname);
         }
-        return @altnames; 
+        return @altnames;
     }
     else {
         return ();
@@ -312,7 +312,7 @@ sub to_altnames_preserve {
             }
             push(@altnames, $altname);
         }
-        return @altnames; 
+        return @altnames;
     }
     else {
         return ();
@@ -403,7 +403,7 @@ a genders node or an alternate node name, 0 if it is not.
 =item B<$obj-E<gt>to_gendname($altnode)>
 
 Returns the genders node name of the specified alternate node name.
-Returns an empty string if the alternate node name is not found in 
+Returns an empty string if the alternate node name is not found in
 the genders file.
 
 =item B<$obj-E<gt>to_gendname_preserve($altnode)>
@@ -415,7 +415,7 @@ genders file.
 =item B<$obj-E<gt>to_altname($node)>
 
 Returns the alternate node name of the specified genders node name.
-Returns an empty string if the genders node name is not found in 
+Returns an empty string if the genders node name is not found in
 the genders file.
 
 =item B<$obj-E<gt>to_altname_preserve($node)>
@@ -448,7 +448,7 @@ Returns a list of alternate node names for each genders node name
 listed in the specified list.  Preserves the genders node name if it
 is not found in the genders file.
 
-=back 
+=back
 
 =head1 AUTHOR
 

--- a/src/Libgendersllnl/Libgendersllnl.pm.in
+++ b/src/Libgendersllnl/Libgendersllnl.pm.in
@@ -12,12 +12,12 @@
 #  was originally a part of the Genders package, but has now been
 #  split off into a separate package.  For details, see
 #  <http://www.llnl.gov/linux/genders/>.
-#  
+#
 #  Gendersllnl is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation; either version 2 of the License, or (at
 #  your option) any later version.
-#   
+#
 #  Gendersllnl is distributed in the hope that it will be useful, but
 #  WITHOUT ANY WARRANTY; without even the implied warranty of
 #  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
@@ -67,12 +67,12 @@ Libgendersllnl - Perl extension for libgendersllnl
 
  $handle->gender_get_cluster([$node])
  $handle->genders_getaltnodes([$attr, [$val]])
- $handle->genders_getaltnodes_preserve([$attr, [$val]])   
- 
+ $handle->genders_getaltnodes_preserve([$attr, [$val]])
+
  $handle->genders_isaltnode($altnode)
  $handle->genders_isnode_or_altnode($nodename)
 
- $handle->genders_to_gendname($altnode)   
+ $handle->genders_to_gendname($altnode)
  $handle->genders_to_gendname_preserve($altnode)
  $handle->genders_to_altname($node)
  $handle->genders_to_altname_preserve($node)
@@ -128,7 +128,7 @@ on error.
 
 =over 4
 
-=item B<$handle-E<gt>genders_to_gendname($altnode)>   
+=item B<$handle-E<gt>genders_to_gendname($altnode)>
 
 Converts the alternate node name to a genders node name.  If $altnode
 is not found, will return an error.  Returns undef on error.

--- a/src/Libgendersllnl/Libgendersllnl.xs
+++ b/src/Libgendersllnl/Libgendersllnl.xs
@@ -12,12 +12,12 @@
  *  was originally a part of the Genders package, but has now been
  *  split off into a separate package.  For details, see
  *  <http://www.llnl.gov/linux/genders/>.
- *  
+ *
  *  Gendersllnl is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU General Public License as
  *  published by the Free Software Foundation; either version 2 of the
  *  License, or (at your option) any later version.
- *  
+ *
  *  Gendersllnl is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
@@ -36,52 +36,52 @@
 #include <genders.h>
 #include "gendersllnl.h"
 
-MODULE = Libgendersllnl         PACKAGE = Libgendersllnl                
+MODULE = Libgendersllnl         PACKAGE = Libgendersllnl
 
 PROTOTYPES: ENABLE
 
 SV *
 GENDERS_ALTNAME_ATTRIBUTE (sv=&PL_sv_undef)
-    SV *sv    
+    SV *sv
     CODE:
         RETVAL = newSVpv(GENDERS_ALTNAME_ATTRIBUTE, 0);
     OUTPUT:
-        RETVAL    
+        RETVAL
 
 SV *
 GENDERS_CLUSTER_ATTRIBUTE (sv=&PL_sv_undef)
-    SV *sv    
+    SV *sv
     CODE:
         RETVAL = newSVpv(GENDERS_CLUSTER_ATTRIBUTE, 0);
     OUTPUT:
-        RETVAL    
+        RETVAL
 
 SV *
 GENDERS_ALL_ATTRIBUTE (sv=&PL_sv_undef)
-    SV *sv    
+    SV *sv
     CODE:
         RETVAL = newSVpv(GENDERS_ALL_ATTRIBUTE, 0);
     OUTPUT:
-        RETVAL    
+        RETVAL
 
-SV * 
+SV *
 genders_get_cluster (handle, node=NULL)
     genders_t handle
-    char *node    
+    char *node
     PREINIT:
         int maxvallen;
         char *buf = NULL;
     CODE:
-        if ((maxvallen = genders_getmaxvallen(handle)) < 0) 
+        if ((maxvallen = genders_getmaxvallen(handle)) < 0)
             goto handle_error;
 
-        if (!(buf = (char *)malloc(maxvallen+1))) 
+        if (!(buf = (char *)malloc(maxvallen+1)))
             goto handle_error;
 
         memset(buf, '\0', maxvallen+1);
 
         if (genders_get_cluster(handle, node, buf, maxvallen + 1) < 0)
-            goto handle_error;            
+            goto handle_error;
 
         RETVAL = newSVpv(buf, 0);
         free(buf);
@@ -89,15 +89,15 @@ genders_get_cluster (handle, node=NULL)
 
         handle_error:
 
-            free(buf);    
-            XSRETURN_UNDEF;    
+            free(buf);
+            XSRETURN_UNDEF;
 
         the_end:
     OUTPUT:
-        RETVAL           
+        RETVAL
 
 AV *
-genders_getaltnodes (handle, attr=NULL, val=NULL)  
+genders_getaltnodes (handle, attr=NULL, val=NULL)
     genders_t handle
     char *attr
     char *val
@@ -121,11 +121,11 @@ genders_getaltnodes (handle, attr=NULL, val=NULL)
         goto the_end;
 
         handle_error:
-        
+
             errnum = genders_errnum(handle);
-           
+
             (void)genders_altnodelist_destroy(handle, altlist);
-        
+
             genders_set_errnum(handle, errnum);
 
             XSRETURN_UNDEF;
@@ -165,9 +165,9 @@ genders_getaltnodes_preserve (handle, attr=NULL, val=NULL)
         handle_error:
 
             errnum = genders_errnum(handle);
-           
+
             (void)genders_altnodelist_destroy(handle, altlist);
-        
+
             genders_set_errnum(handle, errnum);
 
             XSRETURN_UNDEF;
@@ -182,7 +182,7 @@ genders_isaltnode (handle, altnode)
     char *altnode
     CODE:
         RETVAL = genders_isaltnode(handle, altnode);
-    OUTPUT:    
+    OUTPUT:
         RETVAL
 
 int
@@ -191,13 +191,13 @@ genders_isnode_or_altnode (handle, nodename)
     char *nodename
     CODE:
         RETVAL = genders_isnode_or_altnode(handle, nodename);
-    OUTPUT:    
+    OUTPUT:
         RETVAL
 
 SV *
 genders_to_gendname (handle, altnode)
     genders_t handle
-    char *altnode    
+    char *altnode
     PREINIT:
         int maxnodelen;
         char *buf = NULL;
@@ -218,18 +218,18 @@ genders_to_gendname (handle, altnode)
         goto the_end;
 
         handle_error:
-        
-            free(buf);    
+
+            free(buf);
             XSRETURN_UNDEF;
 
         the_end:
     OUTPUT:
-        RETVAL        
+        RETVAL
 
 SV *
 genders_to_gendname_preserve (handle, altnode)
     genders_t handle
-    char *altnode    
+    char *altnode
     PREINIT:
         int maxnodelen;
         char *buf = NULL;
@@ -245,9 +245,9 @@ genders_to_gendname_preserve (handle, altnode)
 
         memset(buf, '\0', maxnodelen+1);
 
-        if (genders_to_gendname_preserve(handle, 
-                                         altnode, 
-                                         buf, 
+        if (genders_to_gendname_preserve(handle,
+                                         altnode,
+                                         buf,
                                          maxnodelen + 1) < 0)
             goto handle_error;
 
@@ -256,19 +256,19 @@ genders_to_gendname_preserve (handle, altnode)
         goto the_end;
 
         handle_error:
-        
-            free(buf);    
+
+            free(buf);
             XSRETURN_UNDEF;
 
         the_end:
     OUTPUT:
-        RETVAL        
+        RETVAL
 
 
 SV *
 genders_to_altname (handle, node)
     genders_t handle
-    char *node    
+    char *node
     PREINIT:
         int maxvallen;
         char *buf = NULL;
@@ -289,18 +289,18 @@ genders_to_altname (handle, node)
         goto the_end;
 
         handle_error:
-        
-            free(buf);    
+
+            free(buf);
             XSRETURN_UNDEF;
 
         the_end:
     OUTPUT:
-        RETVAL        
+        RETVAL
 
 SV *
 genders_to_altname_preserve (handle, node)
     genders_t handle
-    char *node    
+    char *node
     PREINIT:
         int maxvallen;
         char *buf = NULL;
@@ -316,7 +316,7 @@ genders_to_altname_preserve (handle, node)
 
         memset(buf, '\0', maxvallen+1);
 
-        if (genders_to_altname_preserve(handle, 
+        if (genders_to_altname_preserve(handle,
                                         node,
                                         buf,
                                         maxvallen + 1) < 0)
@@ -327,10 +327,10 @@ genders_to_altname_preserve (handle, node)
         goto the_end;
 
         handle_error:
-        
-            free(buf);    
+
+            free(buf);
             XSRETURN_UNDEF;
 
         the_end:
     OUTPUT:
-        RETVAL        
+        RETVAL


### PR DESCRIPTION
Problem: There was some trailing whitespace in the perl extensions code.

Remove it.